### PR TITLE
feat: support tabstop

### DIFF
--- a/src/completion/element-completion-item-povider.ts
+++ b/src/completion/element-completion-item-povider.ts
@@ -1,5 +1,5 @@
 import { TagObject } from '@/hover-tips'
-import { CompletionItemProvider, TextDocument, Position, CancellationToken, ProviderResult, Range, CompletionItem, CompletionContext, CompletionList, CompletionItemKind, workspace } from 'vscode'
+import { CompletionItemProvider, TextDocument, Position, CancellationToken, ProviderResult, Range, CompletionItem, CompletionContext, CompletionList, CompletionItemKind, workspace,SnippetString } from 'vscode'
 
 import CnDocument from '../document/zh-CN'
 import EnDocument from '../document/en-US'
@@ -283,7 +283,13 @@ export class ElementCompletionItemProvider implements CompletionItemProvider<Com
         sortText: `0${key}`,
         detail: 'ElementUI Tag',
         kind: CompletionItemKind.Value,
-        insertText: `${key}></${key}>`,
+        insertText: 
+          new SnippetString()
+          .appendText(`${key}`)
+          .appendTabstop()
+          .appendText('>')
+          .appendTabstop()
+          .appendText(`</${key}>`),
         range
       })
     })


### PR DESCRIPTION
当使用这个插件自动补全代码的时候，光标会默认放在输入属性的位置，如果按下 tab 键，光标会到闭合标签之前的位置，当再次按下 tab 键的时候，光标会移动到标签最后，如下代码展示了光标的位置

```
<el-table${1}>${2}</el-table>
```